### PR TITLE
Return the whole response body since it contains 'previous' and 'next…

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -158,7 +158,7 @@ abstract class Api {
 			return true;
 		}
 
-		return isset($guzzleData['results']) ? (array) $guzzleData['results'] : $guzzleData;
+		return $guzzleData;
 	}
 
 	/**


### PR DESCRIPTION
…' keys needed to paginate trough large data sets like when getting https://api.robinhood.com/instruments/